### PR TITLE
SurrealQL Builder

### DIFF
--- a/src/surreal_query.erl
+++ b/src/surreal_query.erl
@@ -2,12 +2,69 @@
 
 -export([make_one/1, make_all/1]).
 
+-type string_format() :: binary() | atom() | bitstring().
+
+-type block_type() ::
+    {block, Inside :: list(query())}.
+
+-type select_type() ::
+    {select}
+    | {select, Field :: string_format()}.
+
+-type from_type() ::
+    {from, Target :: string_format()}
+    | {from, Targets :: list(string_format())}.
+
+-type where_type() ::
+    {where, {Operator :: string_format(), Left :: string_format(), Right :: term()}}
+    | {where, {Left :: string_format(), Right :: term()}}
+    | {where, Conditions :: list(where_type())}.
+
+-type create_type() ::
+    {create, Something :: string_format()}.
+
+-type set_type() ::
+    {set, {Key :: string_format(), Value :: term()}}
+    | {set, list(set_type())}.
+
+-type var_type() ::
+    {var, {Key :: string_format(), Value :: term()}}.
+
+-type sleep_type() ::
+    {sleep, Millis :: integer()}.
+
+-type delete_type() ::
+    {delete, Something :: string_format()}.
+
+-type update_type() ::
+    {update, Something :: string_format()}.
+
+-type use_type() ::
+    {use, {namespace, Namespace :: string_format()}}
+    | {use, {database, Database :: string_format()}}
+    | {use, {Namespace :: string_format(), Database :: string_format()}}.
+
+-type query() ::
+    block_type()
+    | select_type()
+    | from_type()
+    | where_type()
+    | create_type()
+    | set_type()
+    | var_type()
+    | sleep_type()
+    | delete_type()
+    | update_type()
+    | use_type().
+
+-spec make_all(Queries :: list(list(query()))) -> string().
 make_all(Queries) ->
     Results = lists:map(fun make_one/1, Queries),
     WithFormatted = lists:join("\n", Results),
 
     lists:flatten(WithFormatted).
 
+-spec make_one(Query :: list(query())) -> string().
 make_one(Query) ->
     Results = lists:map(fun make_one_command/1, Query),
     WithFormatted = lists:join(" ", Results) ++ ";",

--- a/src/surreal_query.erl
+++ b/src/surreal_query.erl
@@ -1,0 +1,24 @@
+-module(surreal_query).
+
+-export([make_one/1]).
+
+make_one(Query) ->
+    Results = lists:map(fun make_one_command/1, Query),
+    WithFormatted = lists:join(" ", Results) ++ ";",
+
+    lists:flatten(WithFormatted).
+
+%% @private
+make_one_command({select}) ->
+    "SELECT *";
+make_one_command({select, Field}) when is_atom(Field) ->
+    io_lib:format("SELECT ~s", [Field]);
+make_one_command({select, Fields}) when is_list(Fields) ->
+    ToString = lists:map(fun atom_to_list/1, Fields),
+    WithFormatted = lists:flatten(lists:join(", ", ToString)),
+
+    io_lib:format("SELECT ~s", [WithFormatted]);
+make_one_command({from, Something}) ->
+    io_lib:format("FROM ~s", [Something]);
+make_one_command(_Other) ->
+    "".

--- a/src/surreal_query.erl
+++ b/src/surreal_query.erl
@@ -28,6 +28,7 @@
     | {use, {database, Database :: string_format()}}
     | {use, {Namespace :: string_format(), Database :: string_format()}}.
 
+%% Generate a query string from list of queries (list of operations).
 -spec make_all(Queries :: list(list(query()))) -> string().
 make_all(Queries) ->
     Results = lists:map(fun make_one/1, Queries),
@@ -35,6 +36,7 @@ make_all(Queries) ->
 
     lists:flatten(WithFormatted).
 
+%% Generate a query string from list of operations.
 -spec make_one(Query :: list(query())) -> string().
 make_one(Query) ->
     Results = lists:map(fun make_one_command/1, Query),

--- a/src/surreal_query.erl
+++ b/src/surreal_query.erl
@@ -26,9 +26,9 @@ make_one_command({from, Targets}) when is_list(Targets) ->
 
     io_lib:format("FROM ~s", [WithFormatted]);
 make_one_command({where, {Operator, Left, Right}}) ->
-    io_lib:format("WHERE ~p ~s ~p", [Left, Operator, Right]);
+    io_lib:format("WHERE ~s ~s ~p", [Left, Operator, Right]);
 make_one_command({where, {Left, Right}}) ->
-    io_lib:format("WHERE ~p = ~p", [Left, Right]);
+    io_lib:format("WHERE ~s = ~p", [Left, Right]);
 make_one_command({where, Conditions}) when is_list(Conditions) ->
     NewConditions = lists:map(fun(Condition) -> {where, Condition} end, Conditions),
     WithConcat = lists:map(
@@ -42,5 +42,22 @@ make_one_command({where, Conditions}) when is_list(Conditions) ->
     WithFormatted = lists:flatten(lists:join(", ", WithConcat)),
 
     io_lib:format("WHERE ~s", [WithFormatted]);
+make_one_command({create, Something}) ->
+    io_lib:format("CREATE ~s", [Something]);
+make_one_command({set, {Key, Value}}) ->
+    io_lib:format("SET ~s = ~p", [Key, Value]);
+make_one_command({set, AllKv}) when is_list(AllKv) ->
+    NewKv = lists:map(fun(Kv) -> {set, Kv} end, AllKv),
+    WithConcat = lists:map(
+        fun(Condition) ->
+            [_, _, _, _ | Actual] = make_one_command(Condition),
+            Actual
+        end,
+
+        NewKv
+    ),
+    WithFormatted = lists:flatten(lists:join(", ", WithConcat)),
+
+    io_lib:format("SET ~s", [WithFormatted]);
 make_one_command(_Other) ->
     "".

--- a/src/surreal_query.erl
+++ b/src/surreal_query.erl
@@ -76,5 +76,11 @@ make_one_command({var, {Key, Value}}) ->
 %% SLEEP Builders
 make_one_command({sleep, MsDuration}) ->
     io_lib:format("SLEEP ~pms", [MsDuration]);
+%% DELETE Builders
+make_one_command({delete, Something}) ->
+    io_lib:format("DELETE ~s", [Something]);
+%% UPDATE Builders
+make_one_command({update, Something}) ->
+    io_lib:format("UPDATE ~s", [Something]);
 make_one_command(_Other) ->
     "".

--- a/src/surreal_query.erl
+++ b/src/surreal_query.erl
@@ -9,6 +9,13 @@ make_one(Query) ->
     lists:flatten(WithFormatted).
 
 %% @private
+%% BLOCK Builders
+make_one_command({block, Statements}) when is_list(Statements) ->
+    Results = lists:map(fun make_one_command/1, Statements),
+    WithFormatted = lists:join(" ", Results),
+
+    io_lib:format("(~s)", [WithFormatted]);
+%% SELECT Builders
 make_one_command({select}) ->
     "SELECT *";
 make_one_command({select, Field}) when is_binary(Field); is_atom(Field); is_bitstring(Field) ->
@@ -18,6 +25,7 @@ make_one_command({select, Fields}) when is_list(Fields) ->
     WithFormatted = lists:flatten(lists:join(", ", ToString)),
 
     io_lib:format("SELECT ~s", [WithFormatted]);
+%% FROM Builders
 make_one_command({from, Target}) when is_binary(Target); is_atom(Target); is_bitstring(Target) ->
     io_lib:format("FROM ~s", [Target]);
 make_one_command({from, Targets}) when is_list(Targets) ->
@@ -25,6 +33,7 @@ make_one_command({from, Targets}) when is_list(Targets) ->
     WithFormatted = lists:flatten(lists:join(", ", ToString)),
 
     io_lib:format("FROM ~s", [WithFormatted]);
+%% WHERE Builders
 make_one_command({where, {Operator, Left, Right}}) ->
     io_lib:format("WHERE ~s ~s ~p", [Left, Operator, Right]);
 make_one_command({where, {Left, Right}}) ->
@@ -42,8 +51,10 @@ make_one_command({where, Conditions}) when is_list(Conditions) ->
     WithFormatted = lists:flatten(lists:join(", ", WithConcat)),
 
     io_lib:format("WHERE ~s", [WithFormatted]);
+%% CREATE Builders
 make_one_command({create, Something}) ->
     io_lib:format("CREATE ~s", [Something]);
+%% SET Builders
 make_one_command({set, {Key, Value}}) ->
     io_lib:format("SET ~s = ~p", [Key, Value]);
 make_one_command({set, AllKv}) when is_list(AllKv) ->

--- a/src/surreal_query.erl
+++ b/src/surreal_query.erl
@@ -1,7 +1,6 @@
 -module(surreal_query).
 
 -export([make_one/1, make_all/1]).
--export_type([query/0]).
 
 -type string_format() :: binary() | atom() | bitstring().
 -type query() ::

--- a/src/surreal_query.erl
+++ b/src/surreal_query.erl
@@ -1,61 +1,32 @@
 -module(surreal_query).
 
 -export([make_one/1, make_all/1]).
+-export_type([query/0]).
 
 -type string_format() :: binary() | atom() | bitstring().
-
--type block_type() ::
-    {block, Inside :: list(query())}.
-
--type select_type() ::
-    {select}
-    | {select, Field :: string_format()}.
-
--type from_type() ::
-    {from, Target :: string_format()}
-    | {from, Targets :: list(string_format())}.
-
--type where_type() ::
-    {where, {Operator :: string_format(), Left :: string_format(), Right :: term()}}
+-type query() ::
+    {block, Inside :: list(query())}
+    | {select}
+    | {select, Field :: string_format()}
+    | {from, Target :: string_format()}
+    | {from, Targets :: list(string_format())}
+    | {where, {Operator :: string_format(), Left :: string_format(), Right :: term()}}
     | {where, {Left :: string_format(), Right :: term()}}
-    | {where, Conditions :: list(where_type())}.
-
--type create_type() ::
-    {create, Something :: string_format()}.
-
--type set_type() ::
-    {set, {Key :: string_format(), Value :: term()}}
-    | {set, list(set_type())}.
-
--type var_type() ::
-    {var, {Key :: string_format(), Value :: term()}}.
-
--type sleep_type() ::
-    {sleep, Millis :: integer()}.
-
--type delete_type() ::
-    {delete, Something :: string_format()}.
-
--type update_type() ::
-    {update, Something :: string_format()}.
-
--type use_type() ::
-    {use, {namespace, Namespace :: string_format()}}
+    | {where,
+        Conditions :: list(
+            {Operator :: string_format(), Left :: string_format(), Right :: term()}
+            | {Left :: string_format(), Right :: term()}
+        )}
+    | {create, Something :: string_format()}
+    | {set, {Key :: string_format(), Value :: term()}}
+    | {set, list({Key :: string_format(), Value :: term()})}
+    | {var, {Key :: string_format(), Value :: term()}}
+    | {sleep, Millis :: integer()}
+    | {delete, Something :: string_format()}
+    | {update, Something :: string_format()}
+    | {use, {namespace, Namespace :: string_format()}}
     | {use, {database, Database :: string_format()}}
     | {use, {Namespace :: string_format(), Database :: string_format()}}.
-
--type query() ::
-    block_type()
-    | select_type()
-    | from_type()
-    | where_type()
-    | create_type()
-    | set_type()
-    | var_type()
-    | sleep_type()
-    | delete_type()
-    | update_type()
-    | use_type().
 
 -spec make_all(Queries :: list(list(query()))) -> string().
 make_all(Queries) ->

--- a/src/surreal_query.erl
+++ b/src/surreal_query.erl
@@ -1,6 +1,12 @@
 -module(surreal_query).
 
--export([make_one/1]).
+-export([make_one/1, make_all/1]).
+
+make_all(Queries) ->
+    Results = lists:map(fun make_one/1, Queries),
+    WithFormatted = lists:join("\n", Results),
+
+    lists:flatten(WithFormatted).
 
 make_one(Query) ->
     Results = lists:map(fun make_one_command/1, Query),

--- a/src/surreal_query.erl
+++ b/src/surreal_query.erl
@@ -11,7 +11,7 @@ make_one(Query) ->
 %% @private
 make_one_command({select}) ->
     "SELECT *";
-make_one_command({select, Field}) when is_atom(Field) ->
+make_one_command({select, Field}) when is_binary(Field); is_atom(Field); is_bitstring(Field) ->
     io_lib:format("SELECT ~s", [Field]);
 make_one_command({select, Fields}) when is_list(Fields) ->
     ToString = lists:map(fun atom_to_list/1, Fields),

--- a/src/surreal_query.erl
+++ b/src/surreal_query.erl
@@ -70,5 +70,8 @@ make_one_command({set, AllKv}) when is_list(AllKv) ->
     WithFormatted = lists:flatten(lists:join(", ", WithConcat)),
 
     io_lib:format("SET ~s", [WithFormatted]);
+%% LET Builders
+make_one_command({var, {Key, Value}}) ->
+    io_lib:format("LET $~s = ~p", [Key, Value]);
 make_one_command(_Other) ->
     "".

--- a/src/surreal_query.erl
+++ b/src/surreal_query.erl
@@ -82,5 +82,12 @@ make_one_command({delete, Something}) ->
 %% UPDATE Builders
 make_one_command({update, Something}) ->
     io_lib:format("UPDATE ~s", [Something]);
+%% USE Builders
+make_one_command({use, {namespace, Namespace}}) ->
+    io_lib:format("USE NS ~s", [Namespace]);
+make_one_command({use, {database, Database}}) ->
+    io_lib:format("USE DB ~s", [Database]);
+make_one_command({use, {Namespace, Database}}) ->
+    io_lib:format("USE NS ~s DB ~s", [Namespace, Database]);
 make_one_command(_Other) ->
     "".

--- a/src/surreal_query.erl
+++ b/src/surreal_query.erl
@@ -73,5 +73,8 @@ make_one_command({set, AllKv}) when is_list(AllKv) ->
 %% LET Builders
 make_one_command({var, {Key, Value}}) ->
     io_lib:format("LET $~s = ~p", [Key, Value]);
+%% SLEEP Builders
+make_one_command({sleep, MsDuration}) ->
+    io_lib:format("SLEEP ~pms", [MsDuration]);
 make_one_command(_Other) ->
     "".

--- a/test/surreal_test.erl
+++ b/test/surreal_test.erl
@@ -38,3 +38,20 @@ surreal_test() ->
 
     Result3 = surreal:delete(Pid, "testing:wow"),
     ?assertEqual(Result3, Should1And3).
+
+query_test() ->
+    Query1 = [
+        [
+            {use, {test, test}}
+        ],
+        [
+            {select},
+            {from, users},
+            {where, [{'>', age, 13}, {verified, true}]}
+        ]
+    ],
+
+    Should1 =
+        "USE NS test DB test;\nSELECT * FROM users WHERE age > 13, verified = true;",
+
+    ?assertEqual(surreal_query:make_all(Query1), Should1).


### PR DESCRIPTION
This pull request is for query builders, currently work in progress but you can view the development here without merging the branch. 

This module allows you to build queries in Erlang:
```erl
1> Query = [  
1>   {select, [username, age]},
1>   {from, users}
1> ].
% [{select,[username,age]},{from,users}]
2> surreal_query:make_one(Query).
% "SELECT username, age FROM users;"
```

* This branch only working on `surreal_query.erl` file.