### PR TITLE
Some changes in `send_message`

### DIFF
--- a/src/surreal_prv_websocket.erl
+++ b/src/surreal_prv_websocket.erl
@@ -15,19 +15,15 @@ start_link(Url, NotifyPid) ->
 send_message(Conn, #{<<"id">> := Id} = Msg) ->
     {Pid, MonitorReference} = spawn_monitor(fun() ->
         receive
-            ok ->
-                Encoded = jiffy:encode(Msg),
-                websocket_client:cast(Conn, {text, Encoded}),
-
-                receive
-                    Value ->
-                        exit({ok, Value})
-                end
+            Value ->
+                exit({ok, Value})
         end
     end),
 
     ets:insert(surreal_pool, {Id, Pid}),
-    Pid ! ok,
+
+    Encoded = jiffy:encode(Msg),
+    websocket_client:cast(Conn, {text, Encoded}),
 
     receive
         {'DOWN', MonitorReference, process, Pid, {ok, Result}} ->


### PR DESCRIPTION
There is no need to wait two times in spawned erlang process. Instead lets just send messages asynchronous in function and use created erlang process only for messaging between websocket client and surreal client.