### PR TITLE
Add support for let and unset

### DIFF
--- a/src/surreal.erl
+++ b/src/surreal.erl
@@ -6,9 +6,12 @@
     start_link/1,
     start/1,
     signin/3,
+    signin/6,
     signup/6,
     authenticate/2,
     invalidate/1,
+    set/3,
+    unset/2,
     use/3,
     query/3, query/2,
     select/2,
@@ -92,6 +95,17 @@ authenticate(Connection, Token) ->
     surreal_response:result().
 invalidate(Connection) ->
     gen_server:call(Connection, {invalidate}).
+
+%% @doc Assigns a value as a parameter for this connection.
+-spec set(Connection :: gen_server:server_ref(), Name :: string(), Value :: term()) ->
+    surreal_response:result().
+set(Connection, Name, Value) ->
+    gen_server:call(Connection, {set, unicode:characters_to_binary(Name), Value}).
+
+%% @doc	Removes a parameter for this connection
+-spec unset(Connection :: gen_server:server_ref(), Name :: string()) -> surreal_response:result().
+unset(Connection, Name) ->
+    gen_server:call(Connection, {unset, unicode:characters_to_binary(Name)}).
 
 %% @doc Switch to a specific namespace and database.
 -spec use(Connection :: gen_server:server_ref(), Namespace :: string(), Database :: string()) ->

--- a/src/surreal_gen_server.erl
+++ b/src/surreal_gen_server.erl
@@ -59,6 +59,12 @@ handle_call({authenticate, Token}, _From, Connection) ->
 handle_call({invalidate}, _From, Connection) ->
     Response = send_payload(Connection, <<"invalidate">>, []),
     {reply, Response, Connection};
+handle_call({set, Name, Value}, _From, Connection) ->
+    Response = send_payload(Connection, <<"let">>, [Name, Value]),
+    {reply, Response, Connection};
+handle_call({unset, Name}, _From, Connection) ->
+    Response = send_payload(Connection, <<"unset">>, [Name]),
+    {reply, Response, Connection};
 handle_call({use, Namespace, Database}, _From, Connection) ->
     Response = send_payload(Connection, <<"use">>, [Namespace, Database]),
     {reply, Response, Connection};

--- a/test/surreal_test.erl
+++ b/test/surreal_test.erl
@@ -27,6 +27,7 @@ surreal_test() ->
 
     Should1And3 = {ok, #{<<"id">> => <<"testing:wow">>, <<"name">> => <<"kekw">>}},
     Should2 = {ok, [#{<<"id">> => <<"testing:wow">>, <<"name">> => <<"kekw">>}]},
+    Should4 = {ok, [#{<<"id">> => <<"testing:muchwow">>, <<"value">> => <<"test value">>}]},
 
     Result1 = surreal:create(Pid, "testing:wow", #{
         <<"name">> => <<"kekw">>
@@ -37,7 +38,12 @@ surreal_test() ->
     ?assertEqual(Result2, Should2),
 
     Result3 = surreal:delete(Pid, "testing:wow"),
-    ?assertEqual(Result3, Should1And3).
+    ?assertEqual(Result3, Should1And3),
+
+    surreal:set(Pid, "example", <<"test value">>),
+    [Result4] = surreal:query(Pid, "CREATE testing:muchwow SET value = $example"),
+
+    ?assertEqual(Result4, Should4).
 
 query_test() ->
     Query1 = [


### PR DESCRIPTION
Added support for `let [ name, value ]` and `unset [ name ]` methods which can be used like this:

```erlang
surreal:set(Pid, "example", #{<<"location">> => <<"Turkey">>}).
```

Then can be used like this:

```erlang
surreal:query(Pid, "CREATE person SET location = $example").
```

And you can remove the variable from session like this:

```erlang
surreal:unset(Pid, "example").
```