### PR TITLE
deprecate `change` and `modify` functions

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {erl_opts, [debug_info]}.
-{project_plugins, [erlfmt]}.
+{project_plugins, [erlfmt, rebar3_ex_doc]}.
 {deps, [{websocket_client, "1.5.0"}, {jiffy, "1.1.1"}]}.
 {erlfmt, [write]}.
 {ex_doc, [

--- a/src/surreal.erl
+++ b/src/surreal.erl
@@ -17,10 +17,13 @@
     select/2,
     create/3,
     update/3,
-    change/3,
-    modify/3,
+    merge/3,
+    patch/3,
     delete/2,
-    close/1
+    close/1,
+    %% Deprecated functions
+    change/3,
+    modify/3
 ]).
 
 %% @doc Connects to a local or remote database endpoint.
@@ -163,21 +166,21 @@ update(Connection, TableOrId, Data) ->
     ).
 
 %% @doc Change all records in a table, or a specific record.
--spec change(Connection :: gen_server:server_ref(), TableOrId :: string(), Data :: map()) ->
+-spec merge(Connection :: gen_server:server_ref(), TableOrId :: string(), Data :: map()) ->
     surreal_response:result().
-change(Connection, TableOrId, Data) ->
+merge(Connection, TableOrId, Data) ->
     gen_server:call(
         Connection,
-        {change, unicode:characters_to_binary(TableOrId), Data}
+        {merge, unicode:characters_to_binary(TableOrId), Data}
     ).
 
 %% @doc Applies JSON Patch changes to all records in a table, or a specific record.
--spec modify(Connection :: gen_server:server_ref(), TableOrId :: string(), Data :: map()) ->
+-spec patch(Connection :: gen_server:server_ref(), TableOrId :: string(), Data :: map()) ->
     surreal_response:result().
-modify(Connection, TableOrId, Data) ->
+patch(Connection, TableOrId, Data) ->
     gen_server:call(
         Connection,
-        {modify, unicode:characters_to_binary(TableOrId), Data}
+        {patch, unicode:characters_to_binary(TableOrId), Data}
     ).
 
 %% @doc Deletes all records in a table, or a specific record, from the database.
@@ -193,3 +196,27 @@ delete(Connection, TableOrId) ->
 -spec close(Connection :: gen_server:server_ref()) -> shutdown_ok.
 close(Connection) ->
     gen_server:call(Connection, {stop}).
+
+%%% -----------------------------------
+%%% Following functions are deprecated.
+%%% -----------------------------------
+
+%% @doc Change all records in a table, or a specific record.
+%% @deprecated Please use {@link surreal:merge/3} instead.
+-spec change(Connection :: gen_server:server_ref(), TableOrId :: string(), Data :: map()) ->
+    surreal_response:result().
+change(Connection, TableOrId, Data) ->
+    gen_server:call(
+        Connection,
+        {merge, unicode:characters_to_binary(TableOrId), Data}
+    ).
+
+%% @doc Applies JSON Patch changes to all records in a table, or a specific record.
+%% @deprecated Please use {@link surreal:patch/3} instead.
+-spec modify(Connection :: gen_server:server_ref(), TableOrId :: string(), Data :: map()) ->
+    surreal_response:result().
+modify(Connection, TableOrId, Data) ->
+    gen_server:call(
+        Connection,
+        {patch, unicode:characters_to_binary(TableOrId), Data}
+    ).

--- a/src/surreal_gen_server.erl
+++ b/src/surreal_gen_server.erl
@@ -84,11 +84,11 @@ handle_call({create, TableOrId, Data}, _From, Connection) ->
 handle_call({update, TableOrId, Data}, _From, Connection) ->
     Response = send_payload(Connection, <<"update">>, [TableOrId, Data]),
     {reply, Response, Connection};
-handle_call({change, TableOrId, Data}, _From, Connection) ->
-    Response = send_payload(Connection, <<"change">>, [TableOrId, Data]),
+handle_call({merge, TableOrId, Data}, _From, Connection) ->
+    Response = send_payload(Connection, <<"merge">>, [TableOrId, Data]),
     {reply, Response, Connection};
-handle_call({modify, TableOrId, Data}, _From, Connection) ->
-    Response = send_payload(Connection, <<"modify">>, [TableOrId, Data]),
+handle_call({patch, TableOrId, Data}, _From, Connection) ->
+    Response = send_payload(Connection, <<"patch">>, [TableOrId, Data]),
     {reply, Response, Connection};
 handle_call({delete, TableOrId}, _From, Connection) ->
     Response = send_payload(Connection, <<"delete">>, [TableOrId]),


### PR DESCRIPTION
`change` is renamed as `merge` and `modify` renamed as `patch`. These old names still exists but will be removed in next releases, so better switch to these new names.